### PR TITLE
Add Google Colab link to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# neural-network-challenge-2
- 
+# Neural Network Challenge
+
+## Run this project
+
+[![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/d3rp3tt3/neural-network-challenge-2/blob/main/attrition.ipynb)


### PR DESCRIPTION
This change adds a link to open the Jupyter Notebook in Google Colab. 